### PR TITLE
Add frontend dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>StockSignal Dashboard</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="styles.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-light">
+  <div class="container-fluid py-3" id="app">
+    <h1 class="mb-4">StockSignal Dashboard</h1>
+
+    <div class="row mb-3">
+      <div class="col-md-3">
+        <input type="text" id="symbolInput" class="form-control" placeholder="Symbol (e.g. AAPL)" value="AAPL">
+      </div>
+      <div class="col-md-2">
+        <button id="refreshBtn" class="btn btn-primary w-100">Refresh</button>
+      </div>
+      <div class="col-md-7 d-flex flex-wrap align-items-center" id="toggles">
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="sma50Toggle" checked>
+          <label class="form-check-label" for="sma50Toggle">SMA 50</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="sma200Toggle" checked>
+          <label class="form-check-label" for="sma200Toggle">SMA 200</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="bbToggle" checked>
+          <label class="form-check-label" for="bbToggle">Bollinger Bands</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="rsiToggle" checked>
+          <label class="form-check-label" for="rsiToggle">RSI</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="macdToggle" checked>
+          <label class="form-check-label" for="macdToggle">MACD</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="volumeToggle" checked>
+          <label class="form-check-label" for="volumeToggle">Volume</label>
+        </div>
+        <div class="form-check form-check-inline">
+          <input class="form-check-input" type="checkbox" id="backtestToggle" checked>
+          <label class="form-check-label" for="backtestToggle">Backtest Trades</label>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-lg-9">
+        <canvas id="priceChart" height="300"></canvas>
+        <canvas id="rsiChart" height="150" class="mt-4"></canvas>
+        <canvas id="macdChart" height="150" class="mt-4"></canvas>
+        <h5 class="mt-4">Backtest Results</h5>
+        <div class="row" id="backtestStats" class="mb-2"></div>
+        <canvas id="portfolioChart" height="200" class="mt-2"></canvas>
+      </div>
+      <div class="col-lg-3 mt-4 mt-lg-0">
+        <h5 class="mb-2">LLM Summary</h5>
+        <div id="summary" class="border rounded p-2 bg-white overflow-auto" style="max-height:400px"></div>
+      </div>
+    </div>
+  </div>
+
+  <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,17 @@
+export async function fetchStock(symbol) {
+  const res = await fetch(`/api/stock/${symbol}`);
+  if (!res.ok) throw new Error('Failed to fetch stock');
+  return res.json();
+}
+
+export async function fetchSummary(symbol) {
+  const res = await fetch(`/api/summary/${symbol}`);
+  if (!res.ok) throw new Error('Failed to fetch summary');
+  return res.text();
+}
+
+export async function fetchBacktest(symbol) {
+  const res = await fetch(`/api/backtest/${symbol}`);
+  if (!res.ok) throw new Error('Failed to fetch backtest');
+  return res.json();
+}

--- a/js/chart.js
+++ b/js/chart.js
@@ -1,0 +1,160 @@
+let priceChart, rsiChart, macdChart, portfolioChart;
+
+export function initCharts() {
+  const priceCtx = document.getElementById('priceChart').getContext('2d');
+  const rsiCtx = document.getElementById('rsiChart').getContext('2d');
+  const macdCtx = document.getElementById('macdChart').getContext('2d');
+  const portfolioCtx = document.getElementById('portfolioChart').getContext('2d');
+
+  priceChart = new Chart(priceCtx, {
+    type: 'line',
+    data: { labels: [], datasets: [] },
+    options: { responsive: true, maintainAspectRatio: false }
+  });
+
+  rsiChart = new Chart(rsiCtx, {
+    type: 'line',
+    data: { labels: [], datasets: [] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: { y: { min: 0, max: 100 } }
+    }
+  });
+
+  macdChart = new Chart(macdCtx, {
+    type: 'bar',
+    data: { labels: [], datasets: [] },
+    options: { responsive: true, maintainAspectRatio: false }
+  });
+
+  portfolioChart = new Chart(portfolioCtx, {
+    type: 'line',
+    data: { labels: [], datasets: [] },
+    options: { responsive: true, maintainAspectRatio: false }
+  });
+}
+
+export function updateStockCharts(data, toggles) {
+  const labels = data.dates;
+  priceChart.data.labels = labels;
+  rsiChart.data.labels = labels;
+  macdChart.data.labels = labels;
+
+  priceChart.data.datasets = [
+    {
+      label: 'Close',
+      data: data.close,
+      borderColor: 'black',
+      pointRadius: 0,
+      fill: false,
+    },
+  ];
+
+  if (toggles.sma50) {
+    priceChart.data.datasets.push({
+      label: 'SMA 50',
+      data: data.sma50,
+      borderColor: 'blue',
+      pointRadius: 0,
+      fill: false,
+    });
+  }
+  if (toggles.sma200) {
+    priceChart.data.datasets.push({
+      label: 'SMA 200',
+      data: data.sma200,
+      borderColor: 'red',
+      pointRadius: 0,
+      fill: false,
+    });
+  }
+  if (toggles.bb) {
+    priceChart.data.datasets.push({
+      label: 'BB Upper',
+      data: data.bbUpper,
+      borderColor: 'green',
+      borderDash: [5,5],
+      pointRadius: 0,
+      fill: false,
+    });
+    priceChart.data.datasets.push({
+      label: 'BB Lower',
+      data: data.bbLower,
+      borderColor: 'green',
+      borderDash: [5,5],
+      pointRadius: 0,
+      fill: false,
+    });
+  }
+  if (toggles.volume) {
+    priceChart.data.datasets.push({
+      label: 'Volume',
+      type: 'bar',
+      data: data.volume,
+      backgroundColor: 'rgba(0,0,0,0.1)',
+      yAxisID: 'y1',
+    });
+  }
+
+  if (data.signals) {
+    data.signals.forEach(sig => {
+      priceChart.data.datasets.push({
+        label: sig.type,
+        data: [{ x: labels[sig.index], y: data.close[sig.index] }],
+        pointBackgroundColor: sig.type === 'buy' ? 'green' : 'red',
+        pointRadius: 6,
+        showLine: false,
+      });
+    });
+  }
+
+  rsiChart.data.datasets = [];
+  if (toggles.rsi) {
+    rsiChart.data.datasets.push({
+      label: 'RSI',
+      data: data.rsi,
+      borderColor: 'purple',
+      pointRadius: 0,
+    });
+  }
+
+  macdChart.data.datasets = [];
+  if (toggles.macd) {
+    macdChart.data.datasets.push({
+      label: 'MACD',
+      type: 'line',
+      data: data.macd,
+      borderColor: 'orange',
+      pointRadius: 0,
+    });
+    macdChart.data.datasets.push({
+      label: 'Signal',
+      type: 'line',
+      data: data.macdSignal,
+      borderColor: 'blue',
+      pointRadius: 0,
+    });
+    macdChart.data.datasets.push({
+      label: 'Hist',
+      type: 'bar',
+      data: data.macdHist,
+      backgroundColor: 'rgba(0,0,0,0.3)'
+    });
+  }
+
+  priceChart.update();
+  rsiChart.update();
+  macdChart.update();
+}
+
+export function updatePortfolioChart(backtest) {
+  portfolioChart.data.labels = backtest.dates;
+  portfolioChart.data.datasets = [{
+    label: 'Portfolio Value',
+    data: backtest.values,
+    borderColor: 'teal',
+    pointRadius: 0,
+  }];
+  portfolioChart.update();
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+import { setupUI } from './ui.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupUI();
+});

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,56 @@
+import { fetchStock, fetchSummary, fetchBacktest } from './api.js';
+import { initCharts, updateStockCharts, updatePortfolioChart } from './chart.js';
+
+let toggles = {
+  sma50: true,
+  sma200: true,
+  bb: true,
+  rsi: true,
+  macd: true,
+  volume: true,
+  backtest: true,
+};
+
+export function setupUI() {
+  initCharts();
+  document.getElementById('refreshBtn').addEventListener('click', loadData);
+  ['sma50','sma200','bb','rsi','macd','volume','backtest'].forEach(id => {
+    document.getElementById(id + 'Toggle').addEventListener('change', e => {
+      toggles[id] = e.target.checked;
+      loadData();
+    });
+  });
+  loadData();
+}
+
+async function loadData() {
+  const symbol = document.getElementById('symbolInput').value.trim().toUpperCase();
+  if (!symbol) return;
+  try {
+    const data = await fetchStock(symbol);
+    updateStockCharts(data, toggles);
+
+    if (toggles.backtest) {
+      const bt = await fetchBacktest(symbol);
+      showBacktestStats(bt);
+      updatePortfolioChart(bt);
+    }
+
+    const summary = await fetchSummary(symbol);
+    document.getElementById('summary').innerText = summary;
+  } catch (err) {
+    console.error(err);
+    alert(err.message);
+  }
+}
+
+function showBacktestStats(bt) {
+  const el = document.getElementById('backtestStats');
+  if (!bt) { el.innerHTML = ''; return; }
+  el.innerHTML = `
+    <div class="col-6 col-md-3">Return: ${bt.totalReturn}%</div>
+    <div class="col-6 col-md-3">Win Rate: ${bt.winRate}%</div>
+    <div class="col-6 col-md-3">Drawdown: ${bt.maxDrawdown}%</div>
+    <div class="col-6 col-md-3">Trades: ${bt.trades}</div>
+  `;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,6 @@
+body {
+  font-family: Arial, sans-serif;
+}
+#summary {
+  min-height: 200px;
+}


### PR DESCRIPTION
## Summary
- add HTML layout for charting and controls
- implement modular JS to fetch API data and render with Chart.js
- display LLM summary and backtest results

## Testing
- `node --check js/ui.js`
- `node --check js/api.js`
- `node --check js/chart.js`
- `node --check js/main.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684045b4545c832fb5bd9667902c0fcf