### PR TITLE
Add Express server and API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 *.sqlite
+logs/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # StockSignal
 
-Node.js backend for stock trading signals with Yahoo Finance data and SQLite caching.
+Node.js backend for stock trading signals with Yahoo Finance data and SQLite caching.  
+The server exposes a small REST API used by the web dashboard.
 
 ## Features
 - Fetch historical prices from Yahoo Finance
@@ -9,5 +10,8 @@ Node.js backend for stock trading signals with Yahoo Finance data and SQLite cac
 - Simple backtester
 - Daily LLM summaries cached in JSON
 
-Run with `npm start` after setting up `.env`.
+Run `npm start` after setting up `.env`.  This starts an Express server on
+port `3000` that serves the dashboard and provides `/api/stock/:symbol`,
+`/api/backtest/:symbol` and `/api/summary/:symbol` endpoints.  Backtests are
+now triggered from the frontend instead of running automatically on startup.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,65 @@
-import CONFIG from './config.js';
-import { updateAll, getHistoricalData } from './dataFetcher.js';
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { fetchAndCache, getHistoricalData, updateAll } from './dataFetcher.js';
 import { addIndicators } from './indicators.js';
 import { applyStrategy } from './strategyEngine.js';
 import { backtest } from './backtest.js';
 import { getSummary } from './llm.js';
 import { init as initLogger, info, error } from './logger.js';
 
-async function run() {
-  info('Updating price data');
-  await updateAll();
-  for (const symbol of CONFIG.symbols) {
-    info(`Processing ${symbol}`);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Serve static frontend files
+app.use(express.static(path.resolve(__dirname, '..')));
+
+app.get('/api/stock/:symbol', async (req, res) => {
+  try {
+    const symbol = req.params.symbol.toUpperCase();
+    await fetchAndCache(symbol);
+    let data = getHistoricalData(symbol);
+    data = addIndicators(data);
+    res.json(data);
+  } catch (err) {
+    error(err);
+    res.status(500).json({ error: 'Failed to fetch stock data' });
+  }
+});
+
+app.get('/api/backtest/:symbol', async (req, res) => {
+  try {
+    const symbol = req.params.symbol.toUpperCase();
+    await fetchAndCache(symbol);
     let data = getHistoricalData(symbol);
     data = addIndicators(data);
     data = applyStrategy(data);
     const bt = backtest(data);
-    const summary = await getSummary(symbol, data);
-    info(`${symbol} summary: ${summary}`);
-    info(`${symbol} backtest: ${JSON.stringify(bt)}`);
+    res.json(bt);
+  } catch (err) {
+    error(err);
+    res.status(500).json({ error: 'Failed to run backtest' });
   }
-}
+});
+
+app.get('/api/summary/:symbol', async (req, res) => {
+  try {
+    const symbol = req.params.symbol.toUpperCase();
+    await fetchAndCache(symbol);
+    let data = getHistoricalData(symbol);
+    data = addIndicators(data);
+    const summary = await getSummary(symbol, data);
+    res.send(summary);
+  } catch (err) {
+    error(err);
+    res.status(500).send('Failed to get summary');
+  }
+});
 
 initLogger();
-run().catch(err => error(err));
+updateAll().catch(err => error(err));
+
+app.listen(PORT, () => info(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add Express server to keep the Node process running
- provide `/api/stock/:symbol`, `/api/backtest/:symbol` and `/api/summary/:symbol` endpoints
- document new behaviour in README
- ignore generated log files

## Testing
- `npm install`
- `npm start` *(fails: fetch failed due to network but server still runs)*

------
https://chatgpt.com/codex/tasks/task_b_6841540fb544832fb56513be0149c63f