### PR TITLE
Add LLM reload capability

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,10 +142,13 @@
       <div class="col-lg-4">
         <!-- Market Summary -->
         <div class="card shadow-sm mb-4">
-          <div class="card-header">
+          <div class="card-header d-flex justify-content-between align-items-center">
             <h6 class="card-title mb-0">
               <i class="bi bi-robot me-2"></i>AI Market Analysis
             </h6>
+            <button id="llmReloadBtn" class="btn btn-sm btn-outline-secondary" title="Reload analysis">
+              <i class="bi bi-arrow-clockwise"></i>
+            </button>
           </div>
           <div class="card-body">
             <div id="summary" class="summary-content">

--- a/js/api.js
+++ b/js/api.js
@@ -4,8 +4,9 @@ export async function fetchStock(symbol) {
   return res.json();
 }
 
-export async function fetchSummary(symbol) {
-  const res = await fetch(`/api/summary/${symbol}`);
+export async function fetchSummary(symbol, reload = false) {
+  const url = reload ? `/api/summary/${symbol}?reload=true` : `/api/summary/${symbol}`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error('Failed to fetch summary');
   return res.text();
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -13,7 +13,9 @@ let toggles = {
 
 export function setupUI() {
   initCharts();
-  document.getElementById('refreshBtn').addEventListener('click', loadData);
+  document.getElementById('refreshBtn').addEventListener('click', () => loadData());
+  const reloadBtn = document.getElementById('llmReloadBtn');
+  if (reloadBtn) reloadBtn.addEventListener('click', () => loadData(true));
   ['sma50','sma200','bb','rsi','macd','volume','backtest'].forEach(id => {
     document.getElementById(id + 'Toggle').addEventListener('change', e => {
       toggles[id] = e.target.checked;
@@ -23,7 +25,7 @@ export function setupUI() {
   loadData();
 }
 
-async function loadData() {
+async function loadData(reloadSummary = false) {
   const symbol = document.getElementById('symbolInput').value.trim().toUpperCase();
   if (!symbol) return;
   try {
@@ -36,7 +38,7 @@ async function loadData() {
       updatePortfolioChart(bt);
     }
 
-    const summary = await fetchSummary(symbol);
+    const summary = await fetchSummary(symbol, reloadSummary);
     const summaryEl = document.getElementById('summary');
     summaryEl.innerHTML = `<div class="summary-text">${summary.replace(/\n/g, '<br>')}</div>`;
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { fetchAndCache, getHistoricalData, updateAll } from './dataFetcher.js';
 import { addIndicators } from './indicators.js';
 import { applyStrategy } from './strategyEngine.js';
 import { backtest } from './backtest.js';
-import { getSummary } from './llm.js';
+import { getSummary, clearSummaryCache } from './llm.js';
 import { init as initLogger, info, error } from './logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,10 +77,14 @@ app.get('/api/summary/:symbol', async (req, res) => {
   try {
     const symbol = req.params.symbol.toUpperCase();
     const timeframe = req.query.timeframe || 'all';
+    const reload = req.query.reload === 'true';
+    if (reload) {
+      clearSummaryCache(symbol);
+    }
     await fetchAndCache(symbol);
     let data = getHistoricalData(symbol, timeframe);
     data = addIndicators(data);
-    const summary = await getSummary(symbol, data);
+    const summary = await getSummary(symbol, data, { force: reload });
     res.send(summary);
   } catch (err) {
     error(err);

--- a/src/llm.js
+++ b/src/llm.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import fetch from 'node-fetch';
 import CONFIG from './config.js';
+import { logLLMInteraction, error as logError } from './logger.js';
 
 const cachePath = path.resolve('data', 'llm_cache.json');
 fs.mkdirSync(path.dirname(cachePath), { recursive: true });
@@ -10,16 +11,18 @@ if (fs.existsSync(cachePath)) {
   cache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
 }
 
-export async function getSummary(symbol, indicators) {
+export async function getSummary(symbol, indicators, opts = {}) {
   const today = new Date().toISOString().substring(0, 10);
-  if (cache[symbol] && cache[symbol].date === today) {
+  const force = opts.force === true;
+  if (!force && cache[symbol] && cache[symbol].date === today) {
     return cache[symbol].summary;
   }
-  
+
+  let prompt = '';
   try {
     const latestData = indicators.slice(-1)[0];
-    const prompt = `Analyze this stock data for ${symbol} and provide a brief technical analysis summary (max 3 sentences):
-    
+    prompt = `Analyze this stock data for ${symbol} and provide a brief technical analysis summary (max 3 sentences):
+
 Price: $${latestData.close}
 RSI: ${latestData.rsi14}
 SMA50: ${latestData.sma50}
@@ -83,14 +86,18 @@ Focus on trend direction, momentum, and key signals.`;
     
     cache[symbol] = { date: today, summary };
     fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+    logLLMInteraction(prompt, summary);
     return summary;
   } catch (error) {
-    console.error('LLM Error:', error);
+    logError(error);
     const latestData = indicators.slice(-1)[0];
     const fallbackSummary = generateFallbackAnalysis(symbol, latestData);
-    
+
     cache[symbol] = { date: today, summary: fallbackSummary };
     fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+    if (prompt) {
+      logLLMInteraction(prompt, fallbackSummary);
+    }
     return fallbackSummary;
   }
 }
@@ -112,4 +119,11 @@ function generateFallbackAnalysis(symbol, data) {
   return `${symbol} Analysis: Price $${price}, RSI ${rsi} (${rsiSignal}), Trend: ${trend}.${buySignal} LLM analysis temporarily unavailable.`;
 }
 
-export default { getSummary };
+export function clearSummaryCache(symbol) {
+  if (cache[symbol]) {
+    delete cache[symbol];
+    fs.writeFileSync(cachePath, JSON.stringify(cache, null, 2));
+  }
+}
+
+export default { getSummary, clearSummaryCache };

--- a/src/logger.js
+++ b/src/logger.js
@@ -4,6 +4,7 @@ import path from 'path';
 const logDir = path.resolve('logs');
 fs.mkdirSync(logDir, { recursive: true });
 const logFile = path.join(logDir, 'app.log');
+const llmLogFile = path.join(logDir, 'llm.log');
 
 function write(type, msg) {
   const line = `[${new Date().toISOString()}] [${type}] ${msg}\n`;
@@ -19,6 +20,11 @@ export function error(err) {
   const msg = err && err.stack ? err.stack : String(err);
   console.error(msg);
   write('ERROR', msg);
+}
+
+export function logLLMInteraction(prompt, response) {
+  const entry = `[${new Date().toISOString()}]\nPROMPT: ${prompt}\nRESPONSE: ${response}\n\n`;
+  fs.appendFileSync(llmLogFile, entry);
 }
 
 export function init() {


### PR DESCRIPTION
## Summary
- allow bypassing LLM cache via `reload` query
- front‑end reload button to request fresh LLM analysis
- expose `clearSummaryCache` helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6841a1794e78832f9903c75ba4383628