### PR TITLE
Fix stray merge marker in market analysis section

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
           <div class="card-header d-flex justify-content-between align-items-center">
             <h6 class="card-title mb-0">
               <i class="bi bi-robot me-2"></i>AI Market Analysis
-            </h6><<<<<<< a1ihnu-codex/implement-logging-for-llm-requests-and-responses
+            </h6>
             <button id="llmReloadBtn" class="btn btn-sm btn-outline-secondary" title="Reload analysis">
               <i class="bi bi-arrow-clockwise"></i>
 


### PR DESCRIPTION
## Summary
- clean up `index.html` by removing leftover merge marker text in the AI Market Analysis header

## Testing
- `git diff --color index.html`

------
https://chatgpt.com/codex/tasks/task_b_68441f901ba0832f9b1473ea678a9d63