### PR TITLE
Fix chart height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,17 @@ canvas {
   border-radius: 8px;
 }
 
+/* Limit chart heights to keep them readable */
+#priceChart,
+#portfolioChart {
+  max-height: 350px;
+}
+
+#rsiChart,
+#macdChart {
+  max-height: 200px;
+}
+
 /* Loading states */
 .loading {
   position: relative;


### PR DESCRIPTION
## Summary
- keep price and portfolio charts under 350px tall
- cap RSI and MACD charts at 200px

## Testing
- `npm start` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_b_68441ebeb038832fa078fc45861cc43e